### PR TITLE
Bugfixes for current bakerydemo environment

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -4,5 +4,5 @@ ENV PATH=$PYTHONUSERBASE/bin:$PATH
 ENV PIP_USER=yes
 
 RUN sudo apt-get update  \
- && sudo apt-get install -y enchant \
+ && sudo apt-get install -y enchant-2 \
  && sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,7 +14,7 @@ tasks:
     git clone https://github.com/wagtail/bakerydemo.git
     cd bakerydemo
     cp bakerydemo/settings/local.py.example bakerydemo/settings/local.py
-    echo "DJANGO_SETTINGS_MODULE=bakerydemo.settings.local" > .env
+    cp .env.example .env
     sed -i 's/wagtail>=/# wagtail>=/g' requirements/base.txt
     python -m pip install -r requirements.txt
     python manage.py makemigrations

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,7 @@ tasks:
 - init: |
     git clone https://github.com/wagtail/wagtail.git
     cd wagtail
-    pip install -e '.[testing,docs]' -U
+    pip install -e '.[testing,docs]' -U --config-settings editable_mode=compat
     npm install --no-save
     npm run build
     cd ..


### PR DESCRIPTION
Attempt at fixing #7:

* Don't set `DJANGO_SETTINGS_MODULE=bakerydemo.settings.local` in .env - in the current bakerydemo setup, this should be left at the default of `bakerydemo.settings.dev`
* In current ubuntu releases the `enchant` package is now `enchant-2`

Unfortunately this is now failing for me at the `pip install -e '.[testing,docs]' -U` step, with the error:

```
  Running setup.py develop for wagtail
    error: subprocess-exited-with-error
    
    × python setup.py develop did not run successfully.
    │ exit code: 1
    ╰─> [15 lines of output]
        running develop
        /home/gitpod/.pyenv/versions/3.12.3/lib/python3.12/site-packages/setuptools/command/develop.py:40: EasyInstallDeprecationWarning: easy_install command is deprecated.
        !!
        
                ********************************************************************************
                Please avoid running ``setup.py`` and ``easy_install``.
                Instead, use pypa/build, pypa/installer or other
                standards-based tools.
        
                See https://github.com/pypa/setuptools/issues/917 for details.
                ********************************************************************************
        
        !!
          easy_install.initialize_options(self)
        error: [Errno 17] File exists: '/home/gitpod/.pyenv/versions/3.12.3/bin/python3.12'
        [end of output]
    
    note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× python setup.py develop did not run successfully.
│ exit code: 1
╰─> [15 lines of output]
    running develop
    /home/gitpod/.pyenv/versions/3.12.3/lib/python3.12/site-packages/setuptools/command/develop.py:40: EasyInstallDeprecationWarning: easy_install command is deprecated.
    !!
    
            ********************************************************************************
            Please avoid running ``setup.py`` and ``easy_install``.
            Instead, use pypa/build, pypa/installer or other
            standards-based tools.
    
            See https://github.com/pypa/setuptools/issues/917 for details.
            ********************************************************************************
    
    !!
      easy_install.initialize_options(self)
    error: [Errno 17] File exists: '/home/gitpod/.pyenv/versions/3.12.3/bin/python3.12'
    [end of output]
```

Apparently something in the pip/setuptools chain is trying to execute `pip install -e` by internally calling `./setup.py develop`, despite this being [the deprecated command that `pip install -e` is supposed to replace](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html#summary). This doesn't happen locally with a fresh install of Python 3.12.4 and pip 24.